### PR TITLE
Adds CSV and Markdown outputs, specify location of config store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,16 +9,19 @@ OnServer also allows you to pass a search term on the command line, narrowing th
 ```
 onserver.py
 usage: Find a featureclass, database, mxd, or service in ArcGIS Server
-       [-h] [-q] [-qq] [name]
+       [-h] [-q] [-qq] [-cs] [-csv] [-md] [name]
 
 positional arguments:
-  name              string for which to search (blank returns info on all
-                    services)
+  name                string for which to search (blank returns info on all
+                      services)
 
 optional arguments:
-  -h, --help        show this help message and exit
-  -q, --quiet       only display service names and URLs
-  -qq, --veryquiet  only display service URLs, comma delimited
+  -h, --help          show this help message and exit
+  -q, --quiet         only display service names and URLs
+  -qq, --veryquiet    only display service URLs, comma delimited
+  -cs, --configstore  specify a path path to a configuration store, such as \\server\share\directories\arcgissystem\arcgisinput
+  -csv, --tocsv       display output as comma-separated values
+  -md, --markdown     display output as Markdown
 
 For search strings inlcuding spaces, enclose the query in double-quotes
 ```
@@ -86,6 +89,22 @@ For commonly used feature classes (think parcels or addresses), this can give a 
     WhereYatPresentation (dev/WhereYatPresentation)
 
 to get a brief listing of the map services and the web path to the map services.  You can then use repeated calls to OnServer to drill down into those map services and get the information you need.
+
+#### Piping output to a file
+
+OnServer output can very easily be piped to a file.
+
+Pipe stdout to a text file:
+
+`C:\>onserver.py > output.txt`
+
+Pipe CSV output to a file:
+
+`C:\>onserver.py -csv > output.csv`
+
+Create Markdown output and pipe it to a file:
+
+`C:\>onserver.py -md > output.md`
 
 ### Automation
 

--- a/onserver.py
+++ b/onserver.py
@@ -266,14 +266,17 @@ def get_args():
 
 if __name__ == '__main__':
     args = get_args()
-    try:
-        arcdir = find_arcserver_config()
-    except IOError as e:
-        if e.errno == errno.ENOENT:
-            print 'Cannot find ArcGIS Server configuration.'
-            sys.exit(1)
-        else:
-            raise
+    if args.configstore:
+        arcdir = args.configstore
+    else:
+        try:
+            arcdir = find_arcserver_config()
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                print 'Cannot find ArcGIS Server configuration.'
+                sys.exit(1)
+            else:
+                raise
     manifests = get_manifests(arcdir)
     services = []
     for manifile in manifests:


### PR DESCRIPTION
I added functionality to print the output to CSV or Markdown. Also a flag to allow passing in a config store path. We had an environment where the config store was on a network share and this let's us specify what directory to search.